### PR TITLE
make Scanner.Init() static for local build

### DIFF
--- a/src/JS.uno
+++ b/src/JS.uno
@@ -80,6 +80,6 @@ namespace Fuse.NFC
     extern(!android)
     class Scanner
     {
-        public void Init() {}
+        public static void Init() {}
     }
 }


### PR DESCRIPTION
This seems to fix the local build failure.